### PR TITLE
Update DomainRetrieveResponse.cs

### DIFF
--- a/src/GodaddyWrapper/Responses/DomainRetrieveResponse.cs
+++ b/src/GodaddyWrapper/Responses/DomainRetrieveResponse.cs
@@ -14,7 +14,7 @@ namespace GodaddyWrapper.Responses
         public bool ExposeWhois { get; set; }
         public bool HoldRegistrar { get; set; }
         public bool Locked { get; set; }
-        public string NameServers { get; set; }
+        public string[] NameServers { get; set; }
         public bool Privacy { get; set; }
         public bool RenewAuto { get; set; }
         public DateTime RenewDeadline { get; set; }


### PR DESCRIPTION
When "namesServers" is included in request for RetrieveDomainList, api returns list of NameServers, thus NameServers needs to be a string array otherwise crash on json deserialization